### PR TITLE
🚸 Smalles UI/usability fixes

### DIFF
--- a/src/Components/Organisms/FilterGroup.tsx
+++ b/src/Components/Organisms/FilterGroup.tsx
@@ -1,10 +1,12 @@
-import { Box, Typography, Stack } from '@mui/material';
+import { Box, Typography, Stack, Button } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 
-interface FilterGroupProps<T> {
+interface Props<T> {
   heading: string;
   options: T[];
   selectedValue: T;
   onSelect: (value: T) => void;
+  onClose: () => void;
 }
 
 export const FilterGroup = <T extends string>({
@@ -12,13 +14,20 @@ export const FilterGroup = <T extends string>({
   options,
   selectedValue,
   onSelect,
-}: FilterGroupProps<T>) => {
+  onClose,
+}: Props<T>) => {
   return (
-    <Box>
+    <Box sx={{ textAlign: { xs: 'center', sm: 'left' } }}>
       <Typography variant="body1" fontWeight="bold" sx={{ marginBottom: 1 }}>
         {heading}
       </Typography>
-      <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">
+      <Stack
+        direction="row"
+        spacing={1}
+        flexWrap="wrap"
+        alignItems="center"
+        sx={{ justifyContent: { xs: 'center', sm: 'flex-start' } }}
+      >
         {options.map((option, index) => (
           <Box key={option} sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography
@@ -42,6 +51,16 @@ export const FilterGroup = <T extends string>({
             )}
           </Box>
         ))}
+
+        {selectedValue !== 'Alla' && (
+          <Button
+            onClick={onClose}
+            sx={{ minWidth: 'auto', padding: 0, marginLeft: 1, color: 'black' }}
+            aria-label="rensa filter"
+          >
+            <CloseIcon />
+          </Button>
+        )}
       </Stack>
     </Box>
   );

--- a/src/Pages/ProtectedLayout/Recipes.tsx
+++ b/src/Pages/ProtectedLayout/Recipes.tsx
@@ -31,12 +31,14 @@ export const Recipes = () => {
             options={seasonOptions}
             selectedValue={selectedSeason}
             onSelect={setSelectedSeason}
+            onClose={() => setSelectedSeason('Alla')}
           />
           <FilterGroup
             heading="Filtrera efter väder"
             options={weatherOptions}
             selectedValue={selectedWeather}
             onSelect={setSelectedWeather}
+            onClose={() => setSelectedWeather('Alla')}
           />
         </Stack>
       </Box>

--- a/src/Pages/RootLayout/Home/LinkButton.tsx
+++ b/src/Pages/RootLayout/Home/LinkButton.tsx
@@ -25,6 +25,9 @@ export const LinkButton = ({ activeSection, onToggleScroll }: Props) => {
         variant="h4"
         sx={{
           color: 'black',
+          backgroundColor: 'tertiary.main',
+          textDecoration: 'none',
+          border: '0.5rem, solid, #F8D7AA',
         }}
         onClick={onToggleScroll}
       >


### PR DESCRIPTION
- 1. Added a background to the homepage link so it would be easier to read against different backgrounds
- 2. Add a remove filter "button" (its an x-icon) to remove filters
- 3. 💄 📱 Fix styling for filters on xs screens

1. 
<img width="585" height="303" alt="Skärmavbild 2026-01-12 kl  14 07 49" src="https://github.com/user-attachments/assets/fedd482f-6e58-4c4c-b8b3-fc1bef55bd1d" />

2. 
<img width="706" height="197" alt="Skärmavbild 2026-01-12 kl  14 06 28" src="https://github.com/user-attachments/assets/9bbff748-7e8c-4890-ae67-bb9727358ae2" />

3. 
<img width="290" height="274" alt="Skärmavbild 2026-01-12 kl  14 05 07" src="https://github.com/user-attachments/assets/7cbcd896-5146-483d-8979-062850d993c7" />
